### PR TITLE
cocos2d-x 3.6, TiledMapEditor 0.12.3の環境だとAssertでプログラムが止まる問題を修正

### DIFF
--- a/Classes/Stage.cpp
+++ b/Classes/Stage.cpp
@@ -105,7 +105,11 @@ Sprite* Stage::addPhysicsBody(cocos2d::TMXLayer *layer, cocos2d::Vec2 &coordinat
         // タイルのIDを取り出す
         auto gid = layer->getTileGIDAt(coordinate);
         // タイルのプロパティをmapで取り出す
-        auto properties = _tiledMap->getPropertiesForGID(gid).asValueMap();
+        auto property = _tiledMap->getPropertiesForGID(gid);
+        if (property.isNull() || property.getType() != Value::Type::MAP) {
+            return nullptr;
+        }
+        auto properties = property.asValueMap();
         // プロパティの中からcategoryの値をintとして取り出す
         auto category = properties.at("category").asInt();
         


### PR DESCRIPTION
cocos2d-x3.6, TiledMapEditor0.12.3の環境だと以下のエラーが出てプログラムが止まります。

{
    cocos2d.x.version: cocos2d-x 3.6
    cocos2d.x.compiled_with_gl_state_cache: true
    cocos2d.x.build_type: DEBUG
    gl.supports_vertex_array_object: true
    cocos2d.x.compiled_with_profiler: false
    gl.renderer: Apple Software Renderer
    gl.vendor: Apple Inc.
    gl.max_texture_size: 4096
    gl.max_samples_allowed: 4
    gl.version: OpenGL ES 2.0 APPLE-12.0.5
    gl.supports_S3TC: false
    gl.supports_ATITC: false
    gl.supports_ETC1: false
    gl.max_texture_units: 8
    gl.supports_PVRTC: true
    gl.supports_NPOT: true
    gl.supports_discard_framebuffer: true
    gl.supports_BGRA8888: false
}

Console: listening on  0.0.0.0 : 6010
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
Assert failed: The value type isn't Type::MAP
Assertion failed: (_type == Type::MAP), function asValueMap, file /Users/gen0083/program/cocos/KawazJet/cocos2d/cocos/base/CCValue.cpp, line 649.
(lldb) 

そこでasValueMapを呼び出す前に型チェックを追加しました。
